### PR TITLE
Apply home top bar layout and behavior to visiontest.html

### DIFF
--- a/page/visiontest.html
+++ b/page/visiontest.html
@@ -25,7 +25,16 @@
   .navbar-left{display:flex;align-items:center;gap:10px;font-size:13px}
   .mi-logo{width:26px;height:26px;border-radius:999px;background:radial-gradient(circle at 20% 0%,#38bdf8,#0f172a 60%,#000 80%);display:flex;align-items:center;justify-content:center;overflow:hidden}
   .navbar-title-main{font-weight:600;font-size:13px}.navbar-title-sub{font-size:12px;color:var(--mi-text-sub)}
+  .navbar-menu{display:flex;align-items:center;gap:18px;font-size:12px;color:var(--mi-text-sub)}
+  .navbar-right{display:flex;gap:10px;align-items:center}.navbar-cta{font-size:11px;padding:2px;border-radius:999px;border:none;background:transparent}
   .top-status-bar{font-size:11px;border-radius:999px;background:linear-gradient(135deg,var(--mi-teal),#22c55e);color:#020617;font-weight:600;box-shadow:0 0 18px rgba(34,197,94,.4);padding:4px 10px;white-space:nowrap;font-variant-numeric:tabular-nums}
+  .navbar-menu>a,.navbar-menu>.nav-item>.nav-link{position:relative;padding:4px 0;background:none;border:none;font:inherit;color:inherit;cursor:pointer}
+  .navbar-menu>a::after,.navbar-menu>.nav-item>.nav-link::after{content:"";position:absolute;left:0;bottom:-2px;width:0;height:2px;border-radius:999px;background:linear-gradient(90deg,#38bdf8,#22c55e);transition:width .2s ease}
+  .navbar-menu>a:hover::after,.navbar-menu>.nav-item>.nav-link:hover::after{width:100%}.nav-highlight{color:#fff;font-weight:700}
+  .nav-item{position:relative;display:flex;align-items:center}
+  .nav-submenu{position:absolute;top:120%;left:0;min-width:180px;padding:8px;border-radius:12px;background:rgba(15,23,42,.98);border:1px solid rgba(148,163,184,.5);box-shadow:0 18px 40px rgba(15,23,42,.9);opacity:0;transform:translateY(-4px);pointer-events:none;transition:opacity .18s ease,transform .18s ease;z-index:30}
+  .nav-submenu a{display:block;padding:8px 10px;border-radius:8px;color:#e5e7eb}.nav-submenu a:hover{background:rgba(56,189,248,.16)}
+  .nav-item.open .nav-submenu{opacity:1;transform:translateY(0);pointer-events:auto}
   .notice-bar{max-width:1400px;margin:0 auto 8px;display:flex;align-items:center;justify-content:center;border-radius:999px;background:rgba(56,189,248,.12);color:#e0f2fe;font-weight:500;border:1px solid rgba(56,189,248,.4);font-size:12px;padding:4px 16px}
   .container{display:flex;height:calc(100vh - 78px);max-width:1450px;margin:0 auto;padding:10px 12px 18px;gap:16px}
   .sidebar{width:370px;background:rgba(17,24,39,.72);border:1px solid var(--mi-border);border-radius:16px;padding:14px 12px 18px;overflow-y:auto;backdrop-filter:blur(10px);box-shadow:0 18px 35px rgba(15,23,42,.9)}
@@ -60,6 +69,7 @@
   .scorebar{height:12px;border-radius:999px;background:#020617;overflow:hidden;border:1px solid rgba(55,65,81,.9);margin-top:6px}.scorefill{height:100%;background:linear-gradient(90deg,#38bdf8,#22c55e);width:0%}.small-note{color:var(--mi-text-sub);font-size:11px;line-height:1.5;margin-top:8px}
   .guide-card{padding:14px}.guide-card h3{font-size:13px;margin-bottom:8px}.guide-card p{font-size:12px;color:var(--mi-text-sub);line-height:1.6}
   @media (max-width:1180px){.container{height:auto;min-height:calc(100vh - 78px);flex-direction:column;overflow:auto}body{overflow:auto}.sidebar{width:100%;overflow:visible}.content,.content-inner{overflow:visible}.hero,.layout-grid,.guide-grid{grid-template-columns:1fr}.kpi-grid{grid-template-columns:repeat(2,minmax(0,1fr))}}
+  @media (max-width:900px){.navbar{padding:8px 16px}.navbar-menu{display:none}}
   @media (max-width:720px){.kpi-grid,.inline-2,.inline-3,.button-row{grid-template-columns:1fr}}
 </style>
 </head>
@@ -67,15 +77,36 @@
 <header class="navbar-wrapper">
   <div class="navbar">
     <div class="navbar-left">
-      <div class="mi-logo"><img src="/mnt/data/logo_32.png" alt="" width="26" height="26"></div>
+      <div class="mi-logo">
+        <img src="../img/logo_32.png" alt="" width="26" height="26">
+      </div>
       <div>
         <div class="navbar-title-main">S.PKG MI-Nexus Portal</div>
-        <div class="navbar-title-sub">Vision Equipment Selection Judge v5</div>
+        <div class="navbar-title-sub">Metrology &amp; Inspection</div>
       </div>
     </div>
-    <div class="top-status-bar"><span id="clock"></span></div>
+    <nav class="navbar-menu">
+      <a href="../page/home.html" class="nav-highlight">Home</a>
+      <div class="nav-item nav-item-finance">
+        <button type="button" class="nav-link">재무성과</button>
+        <div class="nav-submenu">
+          <a href="../page/finance-basic.html">일반 재무성과</a>
+          <a href="../page/finance-detail.html">상세 재무성과</a>
+        </div>
+      </div>
+      <a href="../page/plan.html">개발현황</a>
+      <a href="../page/about.html">About</a>
+    </nav>
+    <div class="navbar-right">
+      <button class="navbar-cta" type="button">
+        <div class="top-status-bar"><div id="clock"></div></div>
+      </button>
+      <button class="navbar-cta" type="button">
+        <div class="top-status-bar"><div id="fx-rate"></div></div>
+      </button>
+    </div>
   </div>
-  <div class="notice-bar">검출사이즈 요구/계산/유효/판정을 한 번에 본다. MB/s 와 Mbps는 따로 적는다. bps / Bps 구분 주의.</div>
+  <div class="notice-bar">◈◈◈ MI-Nexus Portal : 하나의 포털 · 하나의 기준 · 한 번의 조회 ◈◈◈</div>
 </header>
 
 <main class="container">
@@ -645,6 +676,31 @@ Rate note: Crop ${fmt(rawRate,2)} MB/s = ${fmt(rawRate*8,2)} Mbps / Full ${fmt(f
   $('scoreFill').style.width=`${score}%`; $('scoreText').textContent=`Selection Score ${score} / 100 · FAIL ${failCount}개 · REVIEW ${reviewCount}개 · ${cameraType==='line' ? 'Line Scan Logic (encoder/line pitch verify)' : 'Area Scan Logic'}`;
 }
 
+
+async function updateFx(){
+  const fxEl=$('fx-rate');
+  if(!fxEl) return;
+  try{
+    const res=await fetch('https://open.er-api.com/v6/latest/USD');
+    const data=await res.json();
+    const krw=data.rates && data.rates.KRW;
+    if(!krw){fxEl.textContent='환율: 데이터 없음';return;}
+    fxEl.textContent=`USD/KRW ${krw.toLocaleString(undefined,{maximumFractionDigits:2})}`;
+  }catch(e){fxEl.textContent='환율: 불러오기 오류';}
+}
+function bindNavbarMenu(){
+  const financeItem=document.querySelector('.nav-item-finance');
+  if(!financeItem) return;
+  const trigger=financeItem.querySelector('.nav-link');
+  trigger.addEventListener('click',e=>{
+    e.preventDefault();
+    e.stopPropagation();
+    financeItem.classList.toggle('open');
+  });
+  document.addEventListener('click',e=>{
+    if(!financeItem.contains(e.target)) financeItem.classList.remove('open');
+  });
+}
 function resetDefaults(){
   const defaults={sensorWidth:11.264,sensorHeight:6.342,resX:4096,resY:3000,pixelSizeX:2.74,pixelSizeY:2.74,bitDepth:8,cameraType:'area',fps:23,colorType:'mono',cameraModel:'똑딱이',focalLength:16,fNumber:4,lensNa:0.125,imageCircle:16,distortion:0.15,mtfUm:5,lensModel:'오이만두',wd:200,targetFovX:120,targetFovY:90,telecentricUse:'no',telecentricMemo:'미적용',minFeature:80,requiredPixels:3,measurePixels:5,heightVariation:1.5,objectSpeed:120,exposureUs:300,waveNm:550,processorType:'cpu',algoLevel:'mid',memMult:4,procBw:1800,ifBw:350,storageBw:500,networkBw:110,accel:1,procMemo:'샘플값',cropX:4096,cropY:3000,useTdi:'no',tdiLine:80000,tdiStage:64,tdiLimit:1,noteMemo:''};
   Object.entries(defaults).forEach(([k,v])=>$(k).value=v);
@@ -660,7 +716,7 @@ $('btnLoad2').addEventListener('click', () => loadSlot(2));
 $('btnLoad3').addEventListener('click', () => loadSlot(3));
 $('btnClearSaves').addEventListener('click', clearSlots);
 ids.forEach(id => $(id).addEventListener('input', calc)); ids.forEach(id => $(id).addEventListener('change', calc));
-updateClock(); setInterval(updateClock, 1000); updateSaveUi('저장준비'); calc();
+updateClock(); setInterval(updateClock, 1000); updateFx(); setInterval(updateFx, 10*60*1000); bindNavbarMenu(); updateSaveUi('저장준비'); calc();
 </script>
 </body>
 </html>


### PR DESCRIPTION
### Motivation
- Align `visiontest.html` top navigation with `home.html` to provide a consistent portal header (logo, title, menu, clock, FX, notice). 
- Restore interactive header features (finance dropdown and FX status) so `visiontest.html` matches portal behavior. 
- Fix logo asset path to use repository image so the header image loads reliably.

### Description
- Replaced the header block in `page/visiontest.html` with the same top-bar structure used in `page/home.html`, preserving the existing Vision Test content below the header. 
- Added CSS for `.navbar-menu`, hover underline, `.nav-submenu` dropdown, `.navbar-right`/`.navbar-cta` layout, and a responsive rule to hide the menu at `max-width:900px`. 
- Added JavaScript `updateFx()` to fetch USD/KRW FX and `bindNavbarMenu()` to handle the finance dropdown, and wired both into initialization (`updateFx()` call + interval and `bindNavbarMenu()` invoked on load). 
- Adjusted the logo path to `../img/logo_32.png` and set the Home nav link highlight state.

### Testing
- Verified changes via `git diff -- page/visiontest.html` to confirm the header/CSS/JS edits were applied. 
- Committed the modified file with `git commit`, which completed successfully. 
- There are no automated unit tests for this static page, so no runtime automated tests were executed.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69e973eb0994832e8d8470b53e979d30)